### PR TITLE
Add GenericBinary wrapper that can be used with DerivingVia

### DIFF
--- a/src/Data/Binary.hs
+++ b/src/Data/Binary.hs
@@ -49,6 +49,8 @@ module Data.Binary (
     , GBinaryGet(..)
     , GBinaryPut(..)
 
+    , GenericBinary(..)
+
     -- * The Get and Put monads
     , Get
     , Put


### PR DESCRIPTION
I think the examples highlight what this wrapper is supposed to accomplish.

```
-- Simple usage with DerivingVia:
data Foo = Foo Int String
    deriving Generic
    deriving Binary via GenericBinary Foo

-- When chaining multiple augmentations:
data Foo = Foo Int String
    deriving Generic
    deriving Binary via Augmentation1 (Augmentation2 (GenericBinary Foo))
```

I am conflicted on the name. Should it be `GBinary` or would that indicate it is supposed to be a class that implements `Binary` in terms of `Generic`?